### PR TITLE
Deleted line '{% load url from future %}' because Django 1.9+ does not support it

### DIFF
--- a/paypal/templates/paypal/express/dashboard/transaction_list.html
+++ b/paypal/templates/paypal/express/dashboard/transaction_list.html
@@ -1,7 +1,6 @@
 {% extends 'dashboard/layout.html' %}
 {% load currency_filters %}
 {% load i18n %}
-{% load url from future %}
 
 {% block title %}
     {% trans "PayPal Express transactions" %} | {{ block.super }}


### PR DESCRIPTION
Deleted line '{% load url from future %}' because Django 1.9+ does not support it